### PR TITLE
Improve OSI Approved cases

### DIFF
--- a/pylic/pylic.py
+++ b/pylic/pylic.py
@@ -37,8 +37,8 @@ def read_license_from_classifier(distribution: Distribution) -> str:
     return "unknown"
 
 
-def read_license_from_metadata(distribution: Distribution) -> str:
-    return distribution.metadata.get("License", "unknown")
+def read_license_from_metadata(distribution: Distribution, fallback: str = "unknown") -> str:
+    return distribution.metadata.get("License", fallback)
 
 
 def read_all_installed_licenses_metadata() -> List[dict]:
@@ -49,6 +49,8 @@ def read_all_installed_licenses_metadata() -> List[dict]:
         license_string = read_license_from_classifier(distribution)
         if license_string == "unknown":
             license_string = read_license_from_metadata(distribution)
+        if license_string == "OSI Approved":
+            license_string = read_license_from_metadata(distribution, fallback="OSI Approved")
 
         installed_licenses.append(
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pylic"
-version = "1.2.1"
+version = "1.2.2"
 description = "Python license checker"
 authors = ["Sandro Huber <sandrochuber@gmail.com>"]
 license = "MIT License"


### PR DESCRIPTION
In some cases the package metadata has only a general classifier set `License :: OSI Approved`, in contrast to e.g. `License :: OSI Approved :: MIT License`. It might be possible that there is in addition to the classifier also a specific `License` set in the metadata. In this case we'll now use the explicitly set license as the actual package license.

Real world example: `scikit-learn`: (https://pypi.org/project/scikit-learn/)
- (Trove) Classifier: `License :: OSI Approved`
- License: `new BSD`.

Old result: `OSI Approved`
**New result: `new BSD`**