### PR TITLE
Unused but listed licenses are ok

### DIFF
--- a/pylic/pylic.py
+++ b/pylic/pylic.py
@@ -77,6 +77,7 @@ def check_for_unnecessary_safe_licenses(safe_licenses: List[str], installed_lice
         print("Safe licenses listed which are not used by any installed package:")
         for unnecessary_safe_license in unnecessary_safe_licenses:
             print(f"  {unnecessary_safe_license}")
+        return False
 
     return True
 
@@ -156,11 +157,11 @@ def main() -> None:
     safe_licenses, unsafe_packages = read_pyproject_file()
     installed_licenses = read_all_installed_licenses_metadata()
     no_unnecessary_safe_licenses = check_for_unnecessary_safe_licenses(safe_licenses, installed_licenses)
-    no_unncessary_unsafe_packages = check_for_unnecessary_unsafe_packages(unsafe_packages, installed_licenses)
+    no_unnecessary_unsafe_packages = check_for_unnecessary_unsafe_packages(unsafe_packages, installed_licenses)
     packages_ok = check_unsafe_packages(unsafe_packages, installed_licenses)
     licenses_ok = check_licenses(safe_licenses, installed_licenses)
 
-    if all([no_unnecessary_safe_licenses, no_unncessary_unsafe_packages, packages_ok, licenses_ok]):
+    if all([no_unnecessary_unsafe_packages, packages_ok, licenses_ok]):
         print("All licenses ok")
     else:
         sys.exit(1)

--- a/pylic/pylic.py
+++ b/pylic/pylic.py
@@ -74,10 +74,9 @@ def check_for_unnecessary_safe_licenses(safe_licenses: List[str], installed_lice
             unnecessary_safe_licenses.append(safe_licenses[index])
 
     if len(unnecessary_safe_licenses) > 0:
-        print("Unncessary safe licenses listed which are not used any installed package:")
+        print("Safe licenses listed which are not used by any installed package:")
         for unnecessary_safe_license in unnecessary_safe_licenses:
             print(f"  {unnecessary_safe_license}")
-        return False
 
     return True
 

--- a/pylic/pylic.py
+++ b/pylic/pylic.py
@@ -156,7 +156,7 @@ def check_licenses(safe_licenses: List[str], installed_licenses: List[dict]) -> 
 def main() -> None:
     safe_licenses, unsafe_packages = read_pyproject_file()
     installed_licenses = read_all_installed_licenses_metadata()
-    no_unnecessary_safe_licenses = check_for_unnecessary_safe_licenses(safe_licenses, installed_licenses)
+    check_for_unnecessary_safe_licenses(safe_licenses, installed_licenses)
     no_unnecessary_unsafe_packages = check_for_unnecessary_unsafe_packages(unsafe_packages, installed_licenses)
     packages_ok = check_unsafe_packages(unsafe_packages, installed_licenses)
     licenses_ok = check_licenses(safe_licenses, installed_licenses)

--- a/tests/test_pylic.py
+++ b/tests/test_pylic.py
@@ -443,7 +443,7 @@ def test_main_prints_errors_and_exits_with_return_value_1_with_unnecessary_unsaf
     assert args[0] == f"  {package}"
 
 
-def test_main_prints_errors_and_exits_with_return_value_1_with_unnecessary_safe_licenses_listed(
+def test_main_prints_errors_and_exits_with_return_value_0_with_unnecessary_safe_licenses_listed(
     mocker: MockerFixture, license: str
 ) -> None:
     mock_read_pyproject_file = mocker.patch("pylic.pylic.read_pyproject_file")
@@ -451,11 +451,9 @@ def test_main_prints_errors_and_exits_with_return_value_1_with_unnecessary_safe_
     mock_read_installed_licenses = mocker.patch("pylic.pylic.read_all_installed_licenses_metadata")
     mock_read_installed_licenses.return_value = []
     print_mock = mocker.patch("builtins.print")
-    sys_exit_mock = mocker.patch("sys.exit")
     main()
-    sys_exit_mock.assert_called_once()
-    assert print_mock.call_count == 2
+    assert print_mock.call_count == 3
     args, _ = print_mock.call_args_list[0]
-    assert args[0] == "Unncessary safe licenses listed which are not used any installed package:"
+    assert args[0] == "Safe licenses listed which are not used by any installed package:"
     args, _ = print_mock.call_args_list[1]
     assert args[0] == f"  {license}"


### PR DESCRIPTION
Listing licenses which are ok for our project, but not used as of yet, should be no problem.

The case is that our legal-guy can list all licenses which are ok (or make a default list for multiple projects), and developers can freely add dependencies without bothering the legal-guy to check if their license is ok.